### PR TITLE
Fix result of 3 funtions to be defined

### DIFF
--- a/src/PasVulkan.POCA.pas
+++ b/src/PasVulkan.POCA.pas
@@ -9808,6 +9808,7 @@ begin
  POCAHashSetString(aContext,aHash,'KeyCode',POCANewNumber(aContext,aKeyEvent.KeyCode));
  POCAHashSetString(aContext,aHash,'ScanCode',POCANewNumber(aContext,aKeyEvent.ScanCode));
  POCAHashSetString(aContext,aHash,'KeyModifiers',POCANewNumber(aContext,ConvertKeyModifiers(aKeyEvent.KeyModifiers)));
+ result:=aHash;
 end;
 
 function POCASetInputEventHashPointer(const aContext:PPOCAContext;const aHash:TPOCAValue;const aPointerEvent:TpvApplicationInputPointerEvent):TPOCAValue;
@@ -9834,12 +9835,14 @@ begin
  POCAHashSetString(aContext,aHash,'Button',POCANewNumber(aContext,ConvertPointerButton(aPointerEvent.Button)));
  POCAHashSetString(aContext,aHash,'Buttons',POCANewNumber(aContext,ConvertPointerButtons(aPointerEvent.Buttons)));
  POCAHashSetString(aContext,aHash,'KeyModifiers',POCANewNumber(aContext,ConvertKeyModifiers(aPointerEvent.KeyModifiers)));
+ result:=aHash;
 end;
 
 function POCASetInputEventHashScroll(const aContext:PPOCAContext;const aHash:TPOCAValue;const aRelativeAmount:TpvVector2):TPOCAValue;
 begin
  POCAHashSetString(aContext,aHash,'EventType',POCANewNumber(aContext,EVENT_SCROLLED));
  POCAHashSetString(aContext,aHash,'RelativeAmount',POCANewVector2(aContext,aRelativeAmount));
+ result:=aHash;
 end;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Functions

- `POCASetInputEventHashScroll`
- `POCASetInputEventHashPointer`
- `POCASetInputEventHashKey`

never set `Result`. Luckily, so far, it seems that no caller was checking the result :) I modified them to return `result:=aHash;` because that's probably what was intended, looking at `POCASetInputEventHashNone` implementation.