### PR TITLE
Add TpvScene3D.TGroup.TAnimation.GetAnimationDuration utility

### DIFF
--- a/src/PasVulkan.Scene3D.pas
+++ b/src/PasVulkan.Scene3D.pas
@@ -2152,6 +2152,7 @@ type EpvScene3D=class(Exception);
                      procedure AssignFromGLTF(const aSourceDocument:TPasGLTF.TDocument;const aSourceAnimation:TPasGLTF.TAnimation);
                      function GetAnimationBeginTime:TpvDouble;
                      function GetAnimationEndTime:TpvDouble;
+                     function GetAnimationDuration:TpvDouble;
                     published
                      property Index:TpvSizeInt read fIndex;
                      property Channels:TpvScene3D.TGroup.TAnimation.TChannels read fChannels;
@@ -13426,6 +13427,11 @@ end;
 function TpvScene3D.TGroup.TAnimation.GetAnimationEndTime:TpvDouble;
 begin
  result:=fAnimationEndTime;
+end;
+
+function TpvScene3D.TGroup.TAnimation.GetAnimationDuration:TpvDouble;
+begin
+ result:=fAnimationEndTime-fAnimationBeginTime;
 end;
 
 { TpvScene3D.TGroup.TCamera }


### PR DESCRIPTION
This PR adds super-trivial `GetAnimationDuration` method that allows to refactor code like this:

```delphi
fXxxDuration:=
  fMainGroup.Animations[fAnimationXxx].GetAnimationEndTime-  
  fMainGroup.Animations[fAnimationXxx].GetAnimationBeginTime;
```

into shorter and simpler (and avoids risk of mistake):

```delphi
fXxxDuration:=fMainGroup.Animations[fAnimationXxx].GetAnimationDuration;
```