### PR TITLE
TpvGenericList<T>.DefaultCompare property

### DIFF
--- a/src/PasVulkan.Collections.pas
+++ b/src/PasVulkan.Collections.pas
@@ -350,6 +350,17 @@ type { TpvDynamicArray }
        procedure Exchange(const aIndex,aWithIndex:TpvSizeInt);
        function GetEnumerator:TValueEnumerator;
        procedure Sort; overload;
+       { Sort using a custom compare function.
+
+         Warning: Right now this sorts one-time using the custom compare function,
+         but then later additions using @link(Add) will maintain order
+         using the default comparer from Generics.Collections
+         (which may behave differently than aCompareFunction).
+         To make future additions use a custom compare function, assign it to
+         @link(DefaultCompare) and then you can call @link(Sort) 
+         without parameters.
+         
+         TODO: Maybe this should just set @link(DefaultCompare) and call Sort()? }
        procedure Sort(const aCompareFunction:TpvTypedSort<T>.TpvTypedSortCompareFunction); overload;
        property Count:TpvSizeInt read fCount write SetCount;
        property Allocated:TpvSizeInt read fAllocated;


### PR DESCRIPTION
The `TpvGenericList<T>` has functionality to "maintain sorted list". After calling `Sort` (the one without parameters and the one with `aCompareFunction`), the `Add` will keep the sorted order. 

However, before this PR, there was no way to change the comparison method used by `Add`, `IndexOf`, `Contains`. While one could use `Sort(aCompareFunction) ` with an explicit callback (to customize this one-time sort), but then later `Add` was always using default comparer (from `Generics.Defaults`, so `TComparer<T>.Default`). 

So this PR exposes `DefaultCompare` to customize what everything (except `Sort(aCompareFunction) ` with an explicit callback) is using for comparison. 
- `Sort` without parameters will use `DefaultCompare`
- `Add` will preserve the order using `DefaultCompare`, if `Sorted`
- `IndexOf` and `Contains` will also use `DefaultCompare`

Note: I made sure this doesn't change any existing behavior (if someone doesn't set `DefaultCompare`). But there's a question what to do with `Sort(aCompareFunction)` overload. Right now, calling it means that we perform one-time sort with custom `aCompareFunction`, but it makes `Sorted`=true, and further additions use default comparer. I didn't change it, to keep backward compat, but maybe it should change (I would recommend it), so that `Sort(aCompareFunction);` is just equivalent to 

- set `DefaultCompare`
- call parameterless `Sort`.
