### PR TITLE
Fix TpvScene3D.TLight.BeforeDestruction

### DIFF
--- a/src/PasVulkan.Scene3D.pas
+++ b/src/PasVulkan.Scene3D.pas
@@ -11110,7 +11110,7 @@ begin
      if (fManualIndex+1)<fSceneInstance.fManualLights.Count then begin
       OtherLight:=fSceneInstance.fManualLights[fSceneInstance.fManualLights.Count-1];
       OtherLight.fManualIndex:=fManualIndex;
-      fSceneInstance.fManualLights[fIndex]:=OtherLight;
+      fSceneInstance.fManualLights[fManualIndex]:=OtherLight;
       fManualIndex:=fSceneInstance.fManualLights.Count-1;
      end;
      fSceneInstance.fManualLights.Extract(fManualIndex);


### PR DESCRIPTION
Code in `TpvScene3D.TLight.BeforeDestruction` was accidentally doing

```
fSceneInstance.fManualLights[fIndex]:=OtherLight;
```

when `fIndex` is obviously -1 (set to -1 by `finally` clause a few lines higher). 

This was causing range check errors when destroying certain animals in our game:)

It seems that it's a copy-paste error, the code under `if fManualIndex>=0 then begin` seems mostly a copy-paste of the code under `if fIndex>=0 then begin`, you possibly copied it and didn't adjust all occurences of `fIndex` -> `fManualIndex`?

Tested the solution on our game, and destroying some animals crashes no more:)