### PR TITLE
Speed-up ZIP SaveToStream, LoadFromStream, and FetchFile

### DIFF
--- a/src/PasVulkan.Archive.ZIP.pas
+++ b/src/PasVulkan.Archive.ZIP.pas
@@ -1880,6 +1880,8 @@ var LocalFileHeader:TpvArchiveZIPLocalFileHeader;
     ItIsAtEnd:boolean;
     ExtensibleDataFieldHeader:TpvArchiveZIPExtensibleDataFieldHeader;
     ExtensibleInfoFieldHeader:TpvArchiveZIP64ExtensibleInfoFieldHeader;
+    CopyBufSize,CopyRemaining,CopyToDo:TpvInt64;
+    CopyBuf:PpvUInt8Array;
  function Decompress(const InStream,OutStream:TStream):boolean;
  const StatusOk=0;
        StatusCRCErr=-1;
@@ -3851,13 +3853,32 @@ begin
 
     CRC32.Initialize;
 
-    case LocalFileHeader.CompressMethod of
-     0:begin
-      if aStream.CopyFrom(fSourceArchive.fStream,CompressedSize)<>CompressedSize then begin
-       raise EpvArchiveZIP.Create('Read error');
+     case LocalFileHeader.CompressMethod of
+      0:begin
+       CopyBufSize:=65536;
+       if CopyBufSize>CompressedSize then begin
+        CopyBufSize:=CompressedSize;
+       end;
+       GetMem(CopyBuf,CopyBufSize);
+       try
+        CopyRemaining:=CompressedSize;
+        while CopyRemaining>0 do begin
+         if CopyRemaining<CopyBufSize then begin
+          CopyToDo:=CopyRemaining;
+         end else begin
+          CopyToDo:=CopyBufSize;
+         end;
+         if fSourceArchive.fStream.Read(CopyBuf^,CopyToDo)<>CopyToDo then begin
+          raise EpvArchiveZIP.Create('Read error');
+         end;
+         CRC32.Update(CopyBuf^,CopyToDo);
+         aStream.WriteBuffer(CopyBuf^,CopyToDo);
+         dec(CopyRemaining,CopyToDo);
+        end;
+       finally
+        FreeMem(CopyBuf);
+       end;
       end;
-      CRC32.Update(aStream);
-     end;
      1..6:begin
       if not Decompress(fSourceArchive.fStream,aStream) then begin
        raise EpvArchiveZIP.Create('Decompression failed');

--- a/src/PasVulkan.Archive.ZIP.pas
+++ b/src/PasVulkan.Archive.ZIP.pas
@@ -4011,7 +4011,7 @@ var LocalFileHeader:TpvArchiveZIPLocalFileHeader;
     CentralFileHeader:TpvArchiveZIPCentralFileHeader;
     Size,CentralFileHeaderOffset,EndCentralFileHeaderOffset,
     ZIP64EndCentralLocatorOffset,ZIP64EndCentralFileHeaderOffset,
-    EntriesThisDisk:TpvInt64;
+    EntriesThisDisk,CentralDirOffset,CentralDirSize:TpvInt64;
     Index,Count,FileCount:TpvSizeInt;
     FileName:TpvRawByteString;
     HasExtensibleInfoFieldHeader,OK:boolean;
@@ -4020,6 +4020,22 @@ var LocalFileHeader:TpvArchiveZIPLocalFileHeader;
     ZIPExtensibleDataFieldHeader:TpvArchiveZIPExtensibleDataFieldHeader;
     ZIP64ExtensibleInfoFieldHeader:TpvArchiveZIP64ExtensibleInfoFieldHeader;
     ZIP64EndCentralLocator:TpvArchiveZIP64EndCentralLocator;
+    TailBuffer:PpvUInt8Array;
+    TailBufferSize,TailBufferOffset:TpvInt64;
+    CentralDirBuffer:PpvUInt8Array;
+    CentralDirBufPos:TpvInt64;
+ procedure CDReadBuffer(out aBuffer;const aCount:TpvSizeInt);
+ begin
+  if (CentralDirBufPos+aCount)>(CentralDirSize) then begin
+   raise EpvArchiveZIP.Create('Read error');
+  end;
+  Move(CentralDirBuffer^[CentralDirBufPos],aBuffer,aCount);
+  inc(CentralDirBufPos,aCount);
+ end;
+ procedure CDSkip(const aCount:TpvInt64);
+ begin
+  inc(CentralDirBufPos,aCount);
+ end;
 begin
 
  Clear;
@@ -4042,67 +4058,65 @@ begin
 
  if LocalFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.LocalFileHeaderSignature.Value then begin
 
-  for Index:=Size-SizeOf(TpvArchiveZipEndCentralFileHeader) downto Size-(65535+SizeOf(TpvArchiveZipEndCentralFileHeader)) do begin
-   if Index<0 then begin
-    break;
-   end else begin
-    fStream.Seek(Index,soFromBeginning);
-    if fStream.Read(EndCentralFileHeader,SizeOf(TpvArchiveZipEndCentralFileHeader))=SizeOf(TpvArchiveZipEndCentralFileHeader) then begin
-     if EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.EndCentralFileHeaderSignature.Value then begin
-      EndCentralFileHeaderOffset:=Index;
-      EndCentralFileHeader.SwapEndiannessIfNeeded;
-      OK:=true;
+  TailBufferSize:=TailScanMaxSize;
+  if TailBufferSize>Size then begin
+   TailBufferSize:=Size;
+  end;
+  TailBufferOffset:=Size-TailBufferSize;
+  GetMem(TailBuffer,TailBufferSize);
+  try
+   fStream.Seek(TailBufferOffset,soFromBeginning);
+   if fStream.Read(TailBuffer^,TailBufferSize)<>TailBufferSize then begin
+    raise EpvArchiveZIP.Create('Read error');
+   end;
+
+   for Index:=TailBufferSize-SizeOf(TpvArchiveZIPEndCentralFileHeader) downto 0 do begin
+    Move(TailBuffer^[Index],EndCentralFileHeader,SizeOf(TpvArchiveZIPEndCentralFileHeader));
+    if EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.EndCentralFileHeaderSignature.Value then begin
+     EndCentralFileHeaderOffset:=TailBufferOffset+Index;
+     EndCentralFileHeader.SwapEndiannessIfNeeded;
+     OK:=true;
+     break;
+    end;
+   end;
+
+   if OK then begin
+
+    for Index:=(EndCentralFileHeaderOffset-TailBufferOffset)-SizeOf(TpvArchiveZIP64EndCentralLocator) downto 0 do begin
+     Move(TailBuffer^[Index],ZIP64EndCentralLocator,SizeOf(TpvArchiveZIP64EndCentralLocator));
+     if ZIP64EndCentralLocator.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64CentralLocatorHeaderSignature.Value then begin
+      ZIP64EndCentralLocator.SwapEndiannessIfNeeded;
+      ZIP64EndCentralLocatorOffset:=TailBufferOffset+Index;
       break;
      end;
     end;
-   end;
-  end;
 
-  if OK then begin
-
-   for Index:=EndCentralFileHeaderOffset-SizeOf(TpvArchiveZIP64EndCentralLocator) downto EndCentralFileHeaderOffset-(65535+SizeOf(TpvArchiveZIP64EndCentralLocator)) do begin
-    if Index<0 then begin
-     break;
+    if ZIP64EndCentralLocatorOffset>=0 then begin
+     OK:=false;
+     ZIP64EndCentralFileHeaderOffset:=ZIP64EndCentralLocator.CentralDirectoryOffset;
+     fStream.Seek(ZIP64EndCentralFileHeaderOffset,soFromBeginning);
+     if fStream.Read(ZIP64EndCentralFileHeader,SizeOf(TpvArchiveZIP64EndCentralFileHeader))=SizeOf(TpvArchiveZIP64EndCentralFileHeader) then begin
+      if ZIP64EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64EndCentralFileHeaderSignature.Value then begin
+       OK:=true;
+       fZIP64:=true;
+      end;
+     end;
     end else begin
-     fStream.Seek(Index,soFromBeginning);
-     if fStream.Read(ZIP64EndCentralLocator,SizeOf(TpvArchiveZIP64EndCentralLocator))=SizeOf(TpvArchiveZIP64EndCentralLocator) then begin
-      if ZIP64EndCentralLocator.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64CentralLocatorHeaderSignature.Value then begin
-       ZIP64EndCentralLocator.SwapEndiannessIfNeeded;
-       ZIP64EndCentralFileHeaderOffset:=Index;
+     for Index:=(EndCentralFileHeaderOffset-TailBufferOffset)-SizeOf(TpvArchiveZIP64EndCentralFileHeader) downto 0 do begin
+      Move(TailBuffer^[Index],ZIP64EndCentralFileHeader,SizeOf(TpvArchiveZIP64EndCentralFileHeader));
+      if ZIP64EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64EndCentralFileHeaderSignature.Value then begin
+       ZIP64EndCentralFileHeader.SwapEndiannessIfNeeded;
+       ZIP64EndCentralFileHeaderOffset:=TailBufferOffset+Index;
+       fZIP64:=true;
        break;
       end;
      end;
     end;
+
    end;
 
-   if ZIP64EndCentralLocatorOffset>=0 then begin
-    OK:=false;
-    ZIP64EndCentralFileHeaderOffset:=ZIP64EndCentralLocator.CentralDirectoryOffset;
-    fStream.Seek(ZIP64EndCentralFileHeaderOffset,soFromBeginning);
-    if fStream.Read(ZIP64EndCentralFileHeader,SizeOf(TpvArchiveZIP64EndCentralFileHeader))=SizeOf(TpvArchiveZIP64EndCentralFileHeader) then begin
-     if ZIP64EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64EndCentralFileHeaderSignature.Value then begin
-      OK:=true;
-      fZIP64:=true;
-     end;
-    end;
-   end else begin
-    for Index:=EndCentralFileHeaderOffset-SizeOf(TpvArchiveZIP64EndCentralFileHeader) downto EndCentralFileHeaderOffset-(65535+SizeOf(TpvArchiveZIP64EndCentralFileHeader)) do begin
-     if Index<0 then begin
-      break;
-     end else begin
-      fStream.Seek(Index,soFromBeginning);
-      if fStream.Read(ZIP64EndCentralFileHeader,SizeOf(TpvArchiveZIP64EndCentralFileHeader))=SizeOf(TpvArchiveZIP64EndCentralFileHeader) then begin
-       if ZIP64EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64EndCentralFileHeaderSignature.Value then begin
-        ZIP64EndCentralFileHeader.SwapEndiannessIfNeeded;
-        ZIP64EndCentralFileHeaderOffset:=Index;
-        fZIP64:=true;
-        break;
-       end;
-      end;
-     end;
-    end;
-   end;
-
+  finally
+   FreeMem(TailBuffer);
   end;
 
  end;
@@ -4111,12 +4125,16 @@ begin
   raise EpvArchiveZIP.Create('Invalid ZIP archive');
  end;
 
- Count:=0;
-
  if (ZIP64EndCentralFileHeaderOffset>=0) and (EndCentralFileHeader.StartDiskOffset=TpvUInt32($ffffffff)) then begin
-  fStream.Seek(ZIP64EndCentralFileHeader.StartDiskOffset,soFromBeginning);
+  CentralDirOffset:=ZIP64EndCentralFileHeader.StartDiskOffset;
  end else begin
-  fStream.Seek(EndCentralFileHeader.StartDiskOffset,soFromBeginning);
+  CentralDirOffset:=EndCentralFileHeader.StartDiskOffset;
+ end;
+
+ if (ZIP64EndCentralFileHeaderOffset>=0) and (EndCentralFileHeader.CentralDirectorySize=TpvUInt32($ffffffff)) then begin
+  CentralDirSize:=ZIP64EndCentralFileHeader.CentralDirectorySize;
+ end else begin
+  CentralDirSize:=EndCentralFileHeader.CentralDirectorySize;
  end;
 
  if (ZIP64EndCentralFileHeaderOffset>=0) and (EndCentralFileHeader.EntriesThisDisk=TpvUInt32($ffff)) then begin
@@ -4125,88 +4143,102 @@ begin
   EntriesThisDisk:=EndCentralFileHeader.EntriesThisDisk;
  end;
 
- repeat
-
-  CentralFileHeaderOffset:=fStream.Position;
-
-  if fStream.Read(CentralFileHeader,SizeOf(TpvArchiveZIPCentralFileHeader))<>SizeOf(TpvArchiveZIPCentralFileHeader) then begin
-   break;
+ GetMem(CentralDirBuffer,CentralDirSize);
+ try
+  fStream.Seek(CentralDirOffset,soFromBeginning);
+  if fStream.Read(CentralDirBuffer^,CentralDirSize)<>CentralDirSize then begin
+   raise EpvArchiveZIP.Create('Read error');
   end;
 
-  if CentralFileHeader.Signature.Value<>TpvArchiveZIPHeaderSignatures.CentralFileHeaderSignature.Value then begin
-   break;
-  end;
+  CentralDirBufPos:=0;
+  Count:=0;
 
-  CentralFileHeader.SwapEndiannessIfNeeded;
+  repeat
 
-  SetLength(FileName,CentralFileHeader.FileNameLength);
-  if CentralFileHeader.FileNameLength>0 then begin
-   if fStream.Read(FileName[1],CentralFileHeader.FileNameLength)<>CentralFileHeader.FileNameLength then begin
+   CentralFileHeaderOffset:=CentralDirOffset+CentralDirBufPos;
+
+   if (CentralDirBufPos+SizeOf(TpvArchiveZIPCentralFileHeader))>CentralDirSize then begin
     break;
    end;
-  end;
+   CDReadBuffer(CentralFileHeader,SizeOf(TpvArchiveZIPCentralFileHeader));
 
-  if Count<EntriesThisDisk then begin
-
-   HasExtensibleInfoFieldHeader:=false;
-
-   if CentralFileHeader.ExtraFieldLength>=SizeOf(TpvArchiveZIPExtensibleDataFieldHeader) then begin
-    StartPosition:=fStream.Position;
-    while (fStream.Position+(SizeOf(ZIPExtensibleDataFieldHeader)-1))<(StartPosition+CentralFileHeader.ExtraFieldLength) do begin
-     fStream.ReadBuffer(ZIPExtensibleDataFieldHeader,SizeOf(TpvArchiveZIPExtensibleDataFieldHeader));
-     ZIPExtensibleDataFieldHeader.SwapEndiannessIfNeeded;
-     From:=fStream.Position;
-     case ZIPExtensibleDataFieldHeader.HeaderID of
-      TpvArchiveZIP64ExtensibleInfoFieldHeader.HeaderID:begin
-       fStream.ReadBuffer(ZIP64ExtensibleInfoFieldHeader,SizeOf(TpvArchiveZIP64ExtensibleInfoFieldHeader));
-       ZIP64ExtensibleInfoFieldHeader.SwapEndiannessIfNeeded;
-       HasExtensibleInfoFieldHeader:=true;
-      end;
-      $7075:begin
-      end;
-     end;
-     if fStream.Seek(From+ZIPExtensibleDataFieldHeader.DataSize,soBeginning)<>From+ZIPExtensibleDataFieldHeader.DataSize then begin
-      raise EpvArchiveZIP.Create('Seek error');
-     end;
-    end;
-   end else if CentralFileHeader.ExtraFieldLength>0 then begin
-    fStream.Seek(CentralFileHeader.ExtraFieldLength,soFromCurrent);
+   if CentralFileHeader.Signature.Value<>TpvArchiveZIPHeaderSignatures.CentralFileHeaderSignature.Value then begin
+    break;
    end;
 
-   fStream.Seek(CentralFileHeader.FileCommentLength,soFromCurrent);
+   CentralFileHeader.SwapEndiannessIfNeeded;
 
-   if length(FileName)>0 then begin
-    FileEntry:=fEntries.Add(FileName);
-    FileEntry.fCentralHeaderPosition:=CentralFileHeaderOffset;
-    FileEntry.fRequiresZIP64:=HasExtensibleInfoFieldHeader;
-    if HasExtensibleInfoFieldHeader then begin
-     if CentralFileHeader.LocalFileHeaderOffset=TpvUInt32($ffffffff) then begin
-      FileEntry.fHeaderPosition:=ZIP64ExtensibleInfoFieldHeader.RelativeHeaderOffset;
+   SetLength(FileName,CentralFileHeader.FileNameLength);
+   if CentralFileHeader.FileNameLength>0 then begin
+    if (CentralDirBufPos+CentralFileHeader.FileNameLength)>CentralDirSize then begin
+     break;
+    end;
+    CDReadBuffer(FileName[1],CentralFileHeader.FileNameLength);
+   end;
+
+   if Count<EntriesThisDisk then begin
+
+    HasExtensibleInfoFieldHeader:=false;
+
+    if CentralFileHeader.ExtraFieldLength>=SizeOf(TpvArchiveZIPExtensibleDataFieldHeader) then begin
+     StartPosition:=CentralDirBufPos;
+     while (CentralDirBufPos+(SizeOf(ZIPExtensibleDataFieldHeader)-1))<(StartPosition+CentralFileHeader.ExtraFieldLength) do begin
+      CDReadBuffer(ZIPExtensibleDataFieldHeader,SizeOf(TpvArchiveZIPExtensibleDataFieldHeader));
+      ZIPExtensibleDataFieldHeader.SwapEndiannessIfNeeded;
+      From:=CentralDirBufPos;
+      case ZIPExtensibleDataFieldHeader.HeaderID of
+       TpvArchiveZIP64ExtensibleInfoFieldHeader.HeaderID:begin
+        CDReadBuffer(ZIP64ExtensibleInfoFieldHeader,SizeOf(TpvArchiveZIP64ExtensibleInfoFieldHeader));
+        ZIP64ExtensibleInfoFieldHeader.SwapEndiannessIfNeeded;
+        HasExtensibleInfoFieldHeader:=true;
+       end;
+       $7075:begin
+       end;
+      end;
+      CentralDirBufPos:=From+ZIPExtensibleDataFieldHeader.DataSize;
+     end;
+    end else if CentralFileHeader.ExtraFieldLength>0 then begin
+     CDSkip(CentralFileHeader.ExtraFieldLength);
+    end;
+
+    CDSkip(CentralFileHeader.FileCommentLength);
+
+    if length(FileName)>0 then begin
+     FileEntry:=fEntries.Add(FileName);
+     FileEntry.fCentralHeaderPosition:=CentralFileHeaderOffset;
+     FileEntry.fRequiresZIP64:=HasExtensibleInfoFieldHeader;
+     if HasExtensibleInfoFieldHeader then begin
+      if CentralFileHeader.LocalFileHeaderOffset=TpvUInt32($ffffffff) then begin
+       FileEntry.fHeaderPosition:=ZIP64ExtensibleInfoFieldHeader.RelativeHeaderOffset;
+      end else begin
+       FileEntry.fHeaderPosition:=CentralFileHeader.LocalFileHeaderOffset;
+      end;
+      if CentralFileHeader.UncompressedSize=TpvUInt32($ffffffff) then begin
+       FileEntry.Size:=ZIP64ExtensibleInfoFieldHeader.CompressedSize;
+      end else begin
+       FileEntry.Size:=CentralFileHeader.UncompressedSize;
+      end;
      end else begin
       FileEntry.fHeaderPosition:=CentralFileHeader.LocalFileHeaderOffset;
-     end;
-     if CentralFileHeader.UncompressedSize=TpvUInt32($ffffffff) then begin
-      FileEntry.Size:=ZIP64ExtensibleInfoFieldHeader.CompressedSize;
-     end else begin
       FileEntry.Size:=CentralFileHeader.UncompressedSize;
      end;
-    end else begin
-     FileEntry.fHeaderPosition:=CentralFileHeader.LocalFileHeaderOffset;
-     FileEntry.Size:=CentralFileHeader.UncompressedSize;
+     FileEntry.fSourceArchive:=self;
     end;
-    FileEntry.fSourceArchive:=self;
+
+    inc(Count);
+
+   end else begin
+
+    Count:=not EntriesThisDisk;
+    break;
+
    end;
 
-   inc(Count);
+  until false;
 
-  end else begin
-
-   Count:=not EntriesThisDisk;
-   break;
-
-  end;
-
- until false;
+ finally
+  FreeMem(CentralDirBuffer);
+ end;
 
  if EntriesThisDisk<>Count then begin
   raise EpvArchiveZIP.Create('Invalid ZIP archive');

--- a/src/PasVulkan.Archive.ZIP.pas
+++ b/src/PasVulkan.Archive.ZIP.pas
@@ -4004,6 +4004,7 @@ begin
 end;
 
 procedure TpvArchiveZIP.LoadFromStream(const aStream:TStream);
+const TailScanMaxSize=65535+SizeOf(TpvArchiveZIPEndCentralFileHeader);
 var LocalFileHeader:TpvArchiveZIPLocalFileHeader;
     EndCentralFileHeader:TpvArchiveZIPEndCentralFileHeader;
     ZIP64EndCentralFileHeader:TpvArchiveZIP64EndCentralFileHeader;
@@ -4751,13 +4752,14 @@ begin
 end;
 
 class function TpvArchiveZIP.FetchFile(const aStream:TStream;const aFileName:TpvUTF8String;const aOutputFileStream:TStream):Boolean;
+const TailScanMaxSize=65535+SizeOf(TpvArchiveZIPEndCentralFileHeader);
 var LocalFileHeader:TpvArchiveZIPLocalFileHeader;
     EndCentralFileHeader:TpvArchiveZIPEndCentralFileHeader;
     ZIP64EndCentralFileHeader:TpvArchiveZIP64EndCentralFileHeader;
     CentralFileHeader:TpvArchiveZIPCentralFileHeader;
     Size,CentralFileHeaderOffset,EndCentralFileHeaderOffset,
     ZIP64EndCentralLocatorOffset,ZIP64EndCentralFileHeaderOffset,
-    EntriesThisDisk,HeaderPosition:TpvInt64;
+    EntriesThisDisk,HeaderPosition,CentralDirOffset,CentralDirSize:TpvInt64;
     Index,Count:TpvSizeInt;
     FileName,SearchFileName:TpvRawByteString;
     HasExtensibleInfoFieldHeader,OK,IsZIP64:boolean;
@@ -4767,6 +4769,22 @@ var LocalFileHeader:TpvArchiveZIPLocalFileHeader;
     ZIP64EndCentralLocator:TpvArchiveZIP64EndCentralLocator;
     TempArchive:TpvArchiveZIP;
     TempEntry:TpvArchiveZIPEntry;
+    TailBuffer:PpvUInt8Array;
+    TailBufferSize,TailBufferOffset:TpvInt64;
+    CentralDirBuffer:PpvUInt8Array;
+    CentralDirBufPos:TpvInt64;
+ procedure CDReadBuffer(out aBuffer;const aCount:TpvSizeInt);
+ begin
+  if (CentralDirBufPos+aCount)>(CentralDirSize) then begin
+   raise EpvArchiveZIP.Create('Read error');
+  end;
+  Move(CentralDirBuffer^[CentralDirBufPos],aBuffer,aCount);
+  inc(CentralDirBufPos,aCount);
+ end;
+ procedure CDSkip(const aCount:TpvInt64);
+ begin
+  inc(CentralDirBufPos,aCount);
+ end;
 begin
 
  result:=false;
@@ -4789,67 +4807,66 @@ begin
 
  if LocalFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.LocalFileHeaderSignature.Value then begin
 
-  for Index:=Size-SizeOf(TpvArchiveZipEndCentralFileHeader) downto Size-(65535+SizeOf(TpvArchiveZipEndCentralFileHeader)) do begin
-   if Index<0 then begin
-    break;
-   end else begin
-    aStream.Seek(Index,soFromBeginning);
-    if aStream.Read(EndCentralFileHeader,SizeOf(TpvArchiveZipEndCentralFileHeader))=SizeOf(TpvArchiveZipEndCentralFileHeader) then begin
-     if EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.EndCentralFileHeaderSignature.Value then begin
-      EndCentralFileHeaderOffset:=Index;
-      EndCentralFileHeader.SwapEndiannessIfNeeded;
-      OK:=true;
+  TailBufferSize:=TailScanMaxSize;
+  if TailBufferSize>Size then begin
+   TailBufferSize:=Size;
+  end;
+  TailBufferOffset:=Size-TailBufferSize;
+  GetMem(TailBuffer,TailBufferSize);
+  try
+   aStream.Seek(TailBufferOffset,soFromBeginning);
+   if aStream.Read(TailBuffer^,TailBufferSize)<>TailBufferSize then begin
+    exit;
+   end;
+
+   for Index:=TailBufferSize-SizeOf(TpvArchiveZIPEndCentralFileHeader) downto 0 do begin
+    Move(TailBuffer^[Index],EndCentralFileHeader,SizeOf(TpvArchiveZIPEndCentralFileHeader));
+    if EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.EndCentralFileHeaderSignature.Value then begin
+     EndCentralFileHeaderOffset:=TailBufferOffset+Index;
+     EndCentralFileHeader.SwapEndiannessIfNeeded;
+     OK:=true;
+     break;
+    end;
+   end;
+
+   if OK then begin
+
+    for Index:=(EndCentralFileHeaderOffset-TailBufferOffset)-SizeOf(TpvArchiveZIP64EndCentralLocator) downto 0 do begin
+     Move(TailBuffer^[Index],ZIP64EndCentralLocator,SizeOf(TpvArchiveZIP64EndCentralLocator));
+     if ZIP64EndCentralLocator.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64CentralLocatorHeaderSignature.Value then begin
+      ZIP64EndCentralLocator.SwapEndiannessIfNeeded;
+      ZIP64EndCentralLocatorOffset:=TailBufferOffset+Index;
       break;
      end;
     end;
-   end;
-  end;
 
-  if OK then begin
-
-   for Index:=EndCentralFileHeaderOffset-SizeOf(TpvArchiveZIP64EndCentralLocator) downto EndCentralFileHeaderOffset-(65535+SizeOf(TpvArchiveZIP64EndCentralLocator)) do begin
-    if Index<0 then begin
-     break;
+    if ZIP64EndCentralLocatorOffset>=0 then begin
+     OK:=false;
+     ZIP64EndCentralFileHeaderOffset:=ZIP64EndCentralLocator.CentralDirectoryOffset;
+     aStream.Seek(ZIP64EndCentralFileHeaderOffset,soFromBeginning);
+     if aStream.Read(ZIP64EndCentralFileHeader,SizeOf(TpvArchiveZIP64EndCentralFileHeader))=SizeOf(TpvArchiveZIP64EndCentralFileHeader) then begin
+      if ZIP64EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64EndCentralFileHeaderSignature.Value then begin
+       OK:=true;
+       IsZIP64:=true;
+      end;
+     end;
     end else begin
-     aStream.Seek(Index,soFromBeginning);
-     if aStream.Read(ZIP64EndCentralLocator,SizeOf(TpvArchiveZIP64EndCentralLocator))=SizeOf(TpvArchiveZIP64EndCentralLocator) then begin
-      if ZIP64EndCentralLocator.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64CentralLocatorHeaderSignature.Value then begin
-       ZIP64EndCentralLocator.SwapEndiannessIfNeeded;
-       ZIP64EndCentralLocatorOffset:=Index;
+
+     for Index:=(EndCentralFileHeaderOffset-TailBufferOffset)-SizeOf(TpvArchiveZIP64EndCentralFileHeader) downto 0 do begin
+      Move(TailBuffer^[Index],ZIP64EndCentralFileHeader,SizeOf(TpvArchiveZIP64EndCentralFileHeader));
+      if ZIP64EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64EndCentralFileHeaderSignature.Value then begin
+       ZIP64EndCentralFileHeader.SwapEndiannessIfNeeded;
+       ZIP64EndCentralFileHeaderOffset:=TailBufferOffset+Index;
+       IsZIP64:=true;
        break;
       end;
      end;
     end;
+
    end;
 
-   if ZIP64EndCentralLocatorOffset>=0 then begin
-    OK:=false;
-    ZIP64EndCentralFileHeaderOffset:=ZIP64EndCentralLocator.CentralDirectoryOffset;
-    aStream.Seek(ZIP64EndCentralFileHeaderOffset,soFromBeginning);
-    if aStream.Read(ZIP64EndCentralFileHeader,SizeOf(TpvArchiveZIP64EndCentralFileHeader))=SizeOf(TpvArchiveZIP64EndCentralFileHeader) then begin
-     if ZIP64EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64EndCentralFileHeaderSignature.Value then begin
-      OK:=true;
-      IsZIP64:=true;
-     end;
-    end;
-   end else begin
-    for Index:=EndCentralFileHeaderOffset-SizeOf(TpvArchiveZIP64EndCentralFileHeader) downto EndCentralFileHeaderOffset-(65535+SizeOf(TpvArchiveZIP64EndCentralFileHeader)) do begin
-     if Index<0 then begin
-      break;
-     end else begin
-      aStream.Seek(Index,soFromBeginning);
-      if aStream.Read(ZIP64EndCentralFileHeader,SizeOf(TpvArchiveZIP64EndCentralFileHeader))=SizeOf(TpvArchiveZIP64EndCentralFileHeader) then begin
-       if ZIP64EndCentralFileHeader.Signature.Value=TpvArchiveZIPHeaderSignatures.Zip64EndCentralFileHeaderSignature.Value then begin
-        ZIP64EndCentralFileHeader.SwapEndiannessIfNeeded;
-        ZIP64EndCentralFileHeaderOffset:=Index;
-        IsZIP64:=true;
-        break;
-       end;
-      end;
-     end;
-    end;
-   end;
-
+  finally
+   FreeMem(TailBuffer);
   end;
 
  end;
@@ -4858,12 +4875,16 @@ begin
   exit;
  end;
 
- Count:=0;
-
  if (ZIP64EndCentralFileHeaderOffset>=0) and (EndCentralFileHeader.StartDiskOffset=TpvUInt32($ffffffff)) then begin
-  aStream.Seek(ZIP64EndCentralFileHeader.StartDiskOffset,soFromBeginning);
+  CentralDirOffset:=ZIP64EndCentralFileHeader.StartDiskOffset;
  end else begin
-  aStream.Seek(EndCentralFileHeader.StartDiskOffset,soFromBeginning);
+  CentralDirOffset:=EndCentralFileHeader.StartDiskOffset;
+ end;
+
+ if (ZIP64EndCentralFileHeaderOffset>=0) and (EndCentralFileHeader.CentralDirectorySize=TpvUInt32($ffffffff)) then begin
+  CentralDirSize:=ZIP64EndCentralFileHeader.CentralDirectorySize;
+ end else begin
+  CentralDirSize:=EndCentralFileHeader.CentralDirectorySize;
  end;
 
  if (ZIP64EndCentralFileHeaderOffset>=0) and (EndCentralFileHeader.EntriesThisDisk=TpvUInt32($ffff)) then begin
@@ -4872,98 +4893,112 @@ begin
   EntriesThisDisk:=EndCentralFileHeader.EntriesThisDisk;
  end;
 
- repeat
-
-  CentralFileHeaderOffset:=aStream.Position;
-
-  if aStream.Read(CentralFileHeader,SizeOf(TpvArchiveZIPCentralFileHeader))<>SizeOf(TpvArchiveZIPCentralFileHeader) then begin
-   break;
+ GetMem(CentralDirBuffer,CentralDirSize);
+ try
+  aStream.Seek(CentralDirOffset,soFromBeginning);
+  if aStream.Read(CentralDirBuffer^,CentralDirSize)<>CentralDirSize then begin
+   exit;
   end;
 
-  if CentralFileHeader.Signature.Value<>TpvArchiveZIPHeaderSignatures.CentralFileHeaderSignature.Value then begin
-   break;
-  end;
+  CentralDirBufPos:=0;
+  Count:=0;
 
-  CentralFileHeader.SwapEndiannessIfNeeded;
+  repeat
 
-  SetLength(FileName,CentralFileHeader.FileNameLength);
-  if CentralFileHeader.FileNameLength>0 then begin
-   if aStream.Read(FileName[1],CentralFileHeader.FileNameLength)<>CentralFileHeader.FileNameLength then begin
+   CentralFileHeaderOffset:=CentralDirOffset+CentralDirBufPos;
+
+   if (CentralDirBufPos+SizeOf(TpvArchiveZIPCentralFileHeader))>CentralDirSize then begin
     break;
    end;
-  end;
+   CDReadBuffer(CentralFileHeader,SizeOf(TpvArchiveZIPCentralFileHeader));
 
-  if Count<EntriesThisDisk then begin
-
-   HasExtensibleInfoFieldHeader:=false;
-
-   if CentralFileHeader.ExtraFieldLength>=SizeOf(TpvArchiveZIPExtensibleDataFieldHeader) then begin
-    StartPosition:=aStream.Position;
-    while (aStream.Position+(SizeOf(ZIPExtensibleDataFieldHeader)-1))<(StartPosition+CentralFileHeader.ExtraFieldLength) do begin
-     aStream.ReadBuffer(ZIPExtensibleDataFieldHeader,SizeOf(TpvArchiveZIPExtensibleDataFieldHeader));
-     ZIPExtensibleDataFieldHeader.SwapEndiannessIfNeeded;
-     From:=aStream.Position;
-     case ZIPExtensibleDataFieldHeader.HeaderID of
-      TpvArchiveZIP64ExtensibleInfoFieldHeader.HeaderID:begin
-       aStream.ReadBuffer(ZIP64ExtensibleInfoFieldHeader,SizeOf(TpvArchiveZIP64ExtensibleInfoFieldHeader));
-       ZIP64ExtensibleInfoFieldHeader.SwapEndiannessIfNeeded;
-       HasExtensibleInfoFieldHeader:=true;
-      end;
-      $7075:begin
-      end;
-     end;
-     if aStream.Seek(From+ZIPExtensibleDataFieldHeader.DataSize,soBeginning)<>From+ZIPExtensibleDataFieldHeader.DataSize then begin
-      break;
-     end;
-    end;
-   end else if CentralFileHeader.ExtraFieldLength>0 then begin
-    aStream.Seek(CentralFileHeader.ExtraFieldLength,soFromCurrent);
+   if CentralFileHeader.Signature.Value<>TpvArchiveZIPHeaderSignatures.CentralFileHeaderSignature.Value then begin
+    break;
    end;
 
-   aStream.Seek(CentralFileHeader.FileCommentLength,soFromCurrent);
+   CentralFileHeader.SwapEndiannessIfNeeded;
 
-   if (length(FileName)>0) and (CorrectPath(FileName)=SearchFileName) then begin
+   SetLength(FileName,CentralFileHeader.FileNameLength);
+   if CentralFileHeader.FileNameLength>0 then begin
+    if (CentralDirBufPos+CentralFileHeader.FileNameLength)>CentralDirSize then begin
+     break;
+    end;
+    CDReadBuffer(FileName[1],CentralFileHeader.FileNameLength);
+   end;
 
-    if not assigned(aOutputFileStream) then begin
-     result:=true;
-     exit;
+   if Count<EntriesThisDisk then begin
+
+    HasExtensibleInfoFieldHeader:=false;
+
+    if CentralFileHeader.ExtraFieldLength>=SizeOf(TpvArchiveZIPExtensibleDataFieldHeader) then begin
+     StartPosition:=CentralDirBufPos;
+     while (CentralDirBufPos+(SizeOf(ZIPExtensibleDataFieldHeader)-1))<(StartPosition+CentralFileHeader.ExtraFieldLength) do begin
+      CDReadBuffer(ZIPExtensibleDataFieldHeader,SizeOf(TpvArchiveZIPExtensibleDataFieldHeader));
+      ZIPExtensibleDataFieldHeader.SwapEndiannessIfNeeded;
+      From:=CentralDirBufPos;
+      case ZIPExtensibleDataFieldHeader.HeaderID of
+       TpvArchiveZIP64ExtensibleInfoFieldHeader.HeaderID:begin
+        CDReadBuffer(ZIP64ExtensibleInfoFieldHeader,SizeOf(TpvArchiveZIP64ExtensibleInfoFieldHeader));
+        ZIP64ExtensibleInfoFieldHeader.SwapEndiannessIfNeeded;
+        HasExtensibleInfoFieldHeader:=true;
+       end;
+       $7075:begin
+       end;
+      end;
+      CentralDirBufPos:=From+ZIPExtensibleDataFieldHeader.DataSize;
+     end;
+    end else if CentralFileHeader.ExtraFieldLength>0 then begin
+     CDSkip(CentralFileHeader.ExtraFieldLength);
     end;
 
-    if HasExtensibleInfoFieldHeader then begin
-     if CentralFileHeader.LocalFileHeaderOffset=TpvUInt32($ffffffff) then begin
-      HeaderPosition:=ZIP64ExtensibleInfoFieldHeader.RelativeHeaderOffset;
+    CDSkip(CentralFileHeader.FileCommentLength);
+
+    if (length(FileName)>0) and (CorrectPath(FileName)=SearchFileName) then begin
+
+     if not assigned(aOutputFileStream) then begin
+      result:=true;
+      exit;
+     end;
+
+     if HasExtensibleInfoFieldHeader then begin
+      if CentralFileHeader.LocalFileHeaderOffset=TpvUInt32($ffffffff) then begin
+       HeaderPosition:=ZIP64ExtensibleInfoFieldHeader.RelativeHeaderOffset;
+      end else begin
+       HeaderPosition:=CentralFileHeader.LocalFileHeaderOffset;
+      end;
      end else begin
       HeaderPosition:=CentralFileHeader.LocalFileHeaderOffset;
      end;
-    end else begin
-     HeaderPosition:=CentralFileHeader.LocalFileHeaderOffset;
+
+     TempArchive:=TpvArchiveZIP.Create;
+     try
+      TempArchive.fStream:=aStream;
+      TempEntry:=TpvArchiveZIPEntry(TempArchive.fEntries.Add(FileName));
+      TempEntry.fHeaderPosition:=HeaderPosition;
+      TempEntry.fSourceArchive:=TempArchive;
+      TempEntry.SaveToStream(aOutputFileStream);
+      result:=true;
+     finally
+      TempArchive.Free;
+     end;
+
+     exit;
+
     end;
 
-    TempArchive:=TpvArchiveZIP.Create;
-    try
-     TempArchive.fStream:=aStream;
-     TempEntry:=TpvArchiveZIPEntry(TempArchive.fEntries.Add(FileName));
-     TempEntry.fHeaderPosition:=HeaderPosition;
-     TempEntry.fSourceArchive:=TempArchive;
-     TempEntry.SaveToStream(aOutputFileStream);
-     result:=true;
-    finally
-     TempArchive.Free;
-    end;
+    inc(Count);
 
-    exit;
+   end else begin
+
+    break;
 
    end;
 
-   inc(Count);
+  until false;
 
-  end else begin
-
-   break;
-
-  end;
-
- until false;
+ finally
+  FreeMem(CentralDirBuffer);
+ end;
 
 end;
 


### PR DESCRIPTION
A lot of time is spent in these 3 procedures when we need to extract or replace small files from a big ZIP file, as most of the file access is unbuffered and byte-wise in this case. These 3 commits improve the situation by doing buffered reads and backward scans from memory. Also when writing to stream, we compute the CRC32 of the copied files on-the-fly, instead of iterating the whole ZIP again afterwards. Have fun. :)